### PR TITLE
Use a new variable for conda vendoring

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,14 +31,14 @@ unset GIT_DIR PYTHONHOME PYTHONPATH LD_LIBRARY_PATH LIBRARY_PATH
 export BUILD_DIR CACHE_DIR BIN_DIR PROFILE_PATH
 
 # Set the Buildpack's internet target for downloading Miniconda distributions.
-# The user can provide BUILDPACK_COMMON_URL to specify a custom target.
+# The user can provide BUILDPACK_CONTINUUM_URL to specify a custom target.
 # Note: this is designed for non-Heroku use, as it does not use the user-provided
 # environment variable mechanism (the ENV_DIR).
-VENDOR_URL="https://repo.continuum.io"
-if [[ -n ${BUILDPACK_COMMON_URL:-} ]]; then
-    VENDOR_URL="$BUILDPACK_COMMON_URL"
+CONTINUUM_URL="https://repo.continuum.io"
+if [[ -n ${BUILDPACK_CONTINUUM_URL:-} ]]; then
+    CONTINUUM_URL="$BUILDPACK_CONTINUUM_URL"
 fi
-export VENDOR_URL
+export CONTINUUM_URL
 
 # Syntax sugar.
 source $BIN_DIR/utils

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -8,7 +8,7 @@ VERSION=${VERSION_ARRAY[1]}
 MINICONDA_VERBOSITY=-v
 
 # The location of the pre-compiled python binary.
-VENDORED_MINICONDA="${VENDOR_URL}/miniconda/${MINICONDA_VERSION}-Linux-x86_64.sh"
+VENDORED_MINICONDA="${CONTINUUM_URL}/miniconda/${MINICONDA_VERSION}-Linux-x86_64.sh"
 
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment"


### PR DESCRIPTION
In order to override the url from where conda is installed, the environment variable BUILDPACK_CONTINUUM_URL must now be set. This change is to allow the buildpack to work in conjunction with the main python buildpack without clashing on environment variables.

Refs plotly/streambed#13243