### PR TITLE
Allow enabling buildpack xtrace

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,6 +66,23 @@ export LANG=en_US.UTF-8
 # Switch to the repo's context.
 cd $BUILD_DIR
 
+# Setup conda and miniconda versions
+MINICONDA_VERSION=Miniconda3-4.5.12
+if [[ -f conda-runtime.txt ]]; then
+  MINICONDA_VERSION=$(cat conda-runtime.txt | tr -d "\n")
+fi
+IFS='-' read -r -a VERSION_ARRAY <<< ${MINICONDA_VERSION}
+CONDA_VERSION=${VERSION_ARRAY[1]}
+
+MINICONDA_VERBOSITY=-v
+if [[ -n "$BUILDPACK_XTRACE" ]]; then
+  MINICONDA_VERBOSITY=-vv
+fi
+
+export CONDA_VERSION
+export MINICONDA_VERSION
+export MINICONDA_VERBOSITY
+
 # Experimental pre_compile hook.
 source $BIN_DIR/steps/hooks/pre_compile
 
@@ -86,6 +103,7 @@ set -e
 mkdir -p $(dirname $PROFILE_PATH)
 
 # Actuall do the conda steps.
+source $BIN_DIR/steps/install_miniconda
 source $BIN_DIR/steps/conda_compile
 
 # ### Finalize
@@ -111,3 +129,5 @@ source $BIN_DIR/steps/hooks/post_compile
 
 deep-mv $BUILD_DIR $ORIG_BUILD_DIR
 deep-mv $TMP_APP_DIR $APP_DIR
+
+puts-step "Conda build complete"

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -1,50 +1,30 @@
 #!/usr/bin/env bash
-set +e
+set -eo pipefail
 
-MINICONDA_VERSION=$(cat conda-runtime.txt | tr -d "\n")
-IFS='-' read -r -a VERSION_ARRAY <<< ${MINICONDA_VERSION}
-VERSION=${VERSION_ARRAY[1]}
-
-MINICONDA_VERBOSITY=-v
-
-# The location of the pre-compiled python binary.
-VENDORED_MINICONDA="${CONTINUUM_URL}/miniconda/${MINICONDA_VERSION}-Linux-x86_64.sh"
-
-if [ ! -d /app/.heroku/miniconda ]; then
-    puts-step "Preparing Python/Miniconda Environment"
-    if ! curl -Ofv $VENDORED_MINICONDA ; then
-        exit 1
-    fi
-
-    bash ${MINICONDA_VERSION}-Linux-x86_64.sh  -p /app/.heroku/miniconda/ -b | indent
-    rm -fr ${MINICONDA_VERSION}-Linux-x86_64.sh
-
-    if [ -f .condarc ]; then
-        puts-step "Copying condarc file to miniconda directory"
-        cp .condarc /app/.heroku/miniconda
-    fi
-
-    echo "nomkl" > $HOME/.heroku/miniconda/conda-meta/pinned
-    echo "python <3.8.0" >> $HOME/.heroku/miniconda/conda-meta/pinned
-    # Pin the conda version if proper version, not `latest` or anything else
-    if [[ $VERSION =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-        echo "conda ==${VERSION}" >> $HOME/.heroku/miniconda/conda-meta/pinned
-    fi
-    echo "added pinned file in $HOME/.heroku/miniconda/conda-meta/pinned"
-
-    conda config --set auto_update_conda False
-    conda install $MINICONDA_VERBOSITY --no-update-deps pip --yes | indent
+puts-step "Initializing .condarc"
+touch /app/.heroku/miniconda/.condarc
+if [[ -f .condarc ]]; then
+  cp -f .condarc /app/.heroku/miniconda
 fi
 
+echo "nomkl" > $HOME/.heroku/miniconda/conda-meta/pinned
+echo "python <3.8.0" >> $HOME/.heroku/miniconda/conda-meta/pinned
+# Pin the conda version if proper version, not `latest` or anything else
+if [[ $CONDA_VERSION =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+  echo "conda ==${CONDA_VERSION}" >> $HOME/.heroku/miniconda/conda-meta/pinned
+fi
+
+conda config --set auto_update_conda False
+conda install $MINICONDA_VERBOSITY --no-update-deps pip --yes | indent
 conda install $MINICONDA_VERBOSITY --no-update-deps nomkl --yes | indent
 
 
 puts-step "Installing dependencies using Conda"
 conda install $MINICONDA_VERBOSITY --no-update-deps --file conda-requirements.txt --yes | indent
 
-if [ -f requirements.txt ]; then
-    puts-step "Installing dependencies using Pip"
-    pip install -r requirements.txt  --exists-action=w | indent
+if [[ -f requirements.txt ]]; then
+  puts-step "Installing dependencies using Pip"
+  pip install -r requirements.txt  --exists-action=w | indent
 fi
 
 # Clean up the installation environment .

--- a/bin/steps/install_miniconda
+++ b/bin/steps/install_miniconda
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+install-miniconda() {
+  declare CONTINUUM_URL="$1" MINICONDA_VERSION="$2"
+
+  # The location of the pre-compiled python binary.
+  VENDORED_MINICONDA="${CONTINUUM_URL}/miniconda/${MINICONDA_VERSION}-Linux-x86_64.sh"
+
+  puts-step "Preparing Python/Miniconda Environment"
+  if ! curl -Ofv $VENDORED_MINICONDA ; then
+    exit 1
+  fi
+
+  bash ${MINICONDA_VERSION}-Linux-x86_64.sh  -p /app/.heroku/miniconda/ -b | indent
+  rm -fr ${MINICONDA_VERSION}-Linux-x86_64.sh
+
+  echo "$MINICONDA_VERSION" > /app/.heroku/miniconda/VERSION
+}
+
+if [[ ! -d /app/.heroku/miniconda ]]; then
+  install-miniconda "$CONTINUUM_URL" "$MINICONDA_VERSION"
+else
+  INSTALLED_MINICONDA_VERSION=$(cat /app/.heroku/miniconda/VERSION 2>/dev/null || true)
+  if [[ "$INSTALLED_MINICONDA_VERSION" != "$MINICONDA_VERSION" ]]; then
+    puts-step "Detected conflicting Miniconda=$INSTALLED_MINICONDA_VERSION, removing"
+    rm -rf /app/.heroku/miniconda
+    install-miniconda "$CONTINUUM_URL" "$MINICONDA_VERSION"
+  fi
+fi


### PR DESCRIPTION
Rather than assuming that the miniconda version should always be stable, delete the old miniconda and install the new one as appropriate.

- move install to new step
- refactor certain environment variables to be "global"
- increase minicondda verbosity with buildpack-xtrace
- enable pipefail so conda builds don't succeed when they should not

Testing Plan

- [ ] Deploy a conda app with this branch set via `.buildpacks` or `BUILDPACK_URL`
- [ ] Deploy with a custom miniconda version
  - Set the contents of `conda-runtime.txt` to `Miniconda3-4.5.13` (currently the buildpack is hardcoded to `Miniconda3-4.5.12`)
  - Verify the deploy output contains `Detected conflicting Miniconda=Miniconda3-4.5.12, removing`
  - Verify app works
- [ ] Deploy the app again without the custom miniconda version
  - Delete `conda-runtime.txt`
  - Verify the deploy output contains `Detected conflicting Miniconda=Miniconda3-4.5.13, removing`
  - Verify app works
