### PR TITLE
Stop building the app when failure

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +e
+set -eo pipefail
 
 MINICONDA_VERSION=$(cat conda-runtime.txt | tr -d "\n")
 IFS='-' read -r -a VERSION_ARRAY <<< ${MINICONDA_VERSION}


### PR DESCRIPTION
Fixes https://github.com/plotly/streambed/issues/14719

This PR changes the options used for the `set` bash builtin so that the deployment fails when there is a failure instead of continuing to build the app.

**This is how I tested this:**

- Using the currently shipped conda buildpack, deploy an app with the following `.condarc` file, which refers to a non-existing conda channel.
```
channels:
  - https://my.anaconda.repo:8080/conda/
```

- Notice that even when it fails to fetch the packages from the non-existing conda channel, it continues to build the app and fails at the end of the build because the app can't be started with the following error:
```
File "/app/app.py", line 1, in <module>
           import dash
       ModuleNotFoundError: No module named 'dash'
       [2021-01-14 21:13:51 +0000] [204] [INFO] Worker exiting (pid: 204)
       [2021-01-14 21:13:51 +0000] [13] [INFO] Shutting down: Master
       [2021-01-14 21:13:51 +0000] [13] [INFO] Reason: Worker failed to boot.
=====> end conda-app web container output
To hamza400.plotly.host:conda-app
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'dokku@hamza400.plotly.host:conda-app'
```

- Add a `.buildpacks` file to the app directory root and point it to this buildpack repo's branch that I pushed my change to and deploy again.

- Notice that now it fails and exits the deployment as soon as it doesn't find the conda channel:
```
remote: An HTTP error occurred when trying to retrieve this URL.
remote: HTTP errors are often intermittent, and a simple retry will get you on your way.
remote: ConnectionError(MaxRetryError("HTTPSConnectionPool(host='my.anaconda.repo', port=8080): Max retries exceeded with url: /conda/linux-64/repodata.json (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f5db4a81898>: Failed to establish a new connection: [Errno -2] Name or service not known'))"))
remote: 
remote: 
To hamza400.plotly.host:conda-app
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'dokku@hamza400.plotly.host:conda-app'
```

- Tested a good deployment as well to confirm it still works.

@tarzzz, could you please review?